### PR TITLE
Force remove apt cache

### DIFF
--- a/build/php/Dockerfile
+++ b/build/php/Dockerfile
@@ -39,7 +39,7 @@ RUN docker-php-ext-install intl \
 
     && apt-get purge -y g++ \
     && apt-get autoremove -y \
-    && rm -r /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* \
 
     # Fix write permissions with shared folders
     && usermod -u 1000 www-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
     mysql:
       restart: always
-      image: mysql
+      image: mysql:5.6
       container_name: mysql
       ports:
         - "3306:3306"
@@ -49,8 +49,6 @@ services:
       environment:
         - MYSQL_DATABASE=world
         - MYSQL_ROOT_PASSWORD=password
-      command: "/build/mysql/sh/permission.sh" #comment or remove this line when run on linux(native) os
-
 
     pma:
       restart: always


### PR DESCRIPTION
I've updated command because it can fail if /var/lib/apt/lists/* doesn't exist

```
rm: cannot remove '/var/lib/apt/lists/*': No such file or directory
```